### PR TITLE
Add simple quiz app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
+# Aplicación de estudio para oposiciones de FP en Automoción
 
+Este proyecto proporciona una sencilla aplicación de consola que permite
+repasar preguntas tipo test relacionadas con el mantenimiento de vehículos.
+
+## Requisitos
+
+- Python 3.7 o superior
+
+## Uso
+
+1. Ejecuta el programa desde la terminal:
+
+```bash
+python3 app.py
+```
+
+2. Se mostrarán las preguntas de forma aleatoria. Escribe el número de la
+   respuesta que consideres correcta.
+3. Al final obtendrás un resumen de aciertos.
+
+## Añadir nuevas preguntas
+
+Las preguntas se encuentran en el archivo `questions.json`. Cada entrada
+sigue el siguiente formato:
+
+```json
+{
+  "question": "Texto de la pregunta",
+  "options": ["Opción 1", "Opción 2", "Opción 3"],
+  "answer": 0
+}
+```
+
+Donde `answer` es el índice (comenzando en 0) de la opción correcta.
+
+Puedes añadir tantas preguntas como desees siguiendo el mismo esquema.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,43 @@
+import json
+import random
+import os
+
+# Load questions from JSON file
+QUESTIONS_FILE = os.path.join(os.path.dirname(__file__), 'questions.json')
+
+def load_questions():
+    with open(QUESTIONS_FILE, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+def ask_question(q):
+    print('\n' + q['question'])
+    options = q['options']
+    for idx, opt in enumerate(options, 1):
+        print(f" {idx}. {opt}")
+    while True:
+        try:
+            choice = int(input('Tu respuesta: ')) - 1
+            if 0 <= choice < len(options):
+                break
+            else:
+                print('Elige un número válido.')
+        except ValueError:
+            print('Introduce un número.')
+    is_correct = choice == q['answer']
+    if is_correct:
+        print('Correcto!')
+    else:
+        print(f"Incorrecto. La respuesta correcta es: {options[q['answer']]}")
+    return is_correct
+
+def run_quiz():
+    questions = load_questions()
+    random.shuffle(questions)
+    score = 0
+    for q in questions:
+        if ask_question(q):
+            score += 1
+    print(f"\nHas obtenido {score} de {len(questions)} respuestas correctas.")
+
+if __name__ == '__main__':
+    run_quiz()

--- a/questions.json
+++ b/questions.json
@@ -1,0 +1,29 @@
+[
+  {
+    "question": "¿Cuál es la función principal de la correa de distribución?",
+    "options": [
+      "Evitar que el motor se sobrecaliente",
+      "Sincronizar la rotación del cigüeñal y el árbol de levas",
+      "Lubricar los pistones"
+    ],
+    "answer": 1
+  },
+  {
+    "question": "¿Qué herramienta se utiliza para medir la presión de inflado de un neumático?",
+    "options": [
+      "Dinámetro",
+      "Calibre",
+      "Manómetro"
+    ],
+    "answer": 2
+  },
+  {
+    "question": "¿Qué elemento del sistema de frenos se encarga de multiplicar la fuerza ejercida por el conductor?",
+    "options": [
+      "El servofreno",
+      "El cilindro maestro",
+      "La pinza de freno"
+    ],
+    "answer": 0
+  }
+]


### PR DESCRIPTION
## Summary
- create a quiz application (`app.py`) that loads questions from `questions.json`
- add a few example questions about mantenimiento de vehículos
- document how to run the app and add questions in `README.md`

## Testing
- `python3 app.py`

------
https://chatgpt.com/codex/tasks/task_e_6863d0e7e7d8832daaad18bef7c37fa9