### PR TITLE
Add CLI package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
+# RODA
 
+Aplicación de práctica desde la línea de comandos.
+
+```bash
+python -m app
+```
+
+O bien, tras instalar el paquete:
+
+```bash
+pip install -e .
+roda
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,3 @@
+"""RODA application package."""
+
+__all__ = ["cli"]

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for running ``python -m app``."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,0 +1,25 @@
+"""Command-line interface for RODA app."""
+
+from typing import Callable
+
+
+
+def main() -> None:
+    """Run the main menu to start practice sessions."""
+    while True:
+        print("\nMENU PRINCIPAL")
+        print("1. Iniciar sesión de práctica")
+        print("2. Salir")
+        choice = input("Seleccione una opción: ").strip()
+        if choice == "1":
+            print("Iniciando sesión de práctica...")
+            # Aquí se podría agregar la lógica real de inicio de sesión
+        elif choice == "2":
+            print("¡Hasta pronto!")
+            break
+        else:
+            print("Opción no válida. Intente nuevamente.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "roda"
+version = "0.1.0"
+description = "Herramienta de práctica desde la línea de comandos"
+readme = "README.md"
+requires-python = ">=3.8"
+
+[project.scripts]
+roda = "app.cli:main"


### PR DESCRIPTION
## Summary
- add `app` package with CLI
- configure `pyproject.toml` for `roda` command
- document usage

## Testing
- `python -m app <<'EOF'
2
EOF`
- `python app/cli.py <<'EOF'
2
EOF`
- `pip install -e .`
- `roda <<'EOF'
2
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6863d16e5774832d9c08fdac34e7486c