### PR TITLE
Añadir scaffold Android (Kotlin) para automatizar Hotspot según Bluetooth del coche

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
+# Car Hotspot Automation (Kotlin)
 
+Implementación base para automatizar el encendido/apagado del hotspot en función de la conexión Bluetooth del coche.
+
+## Entregables incluidos
+
+- `CarBluetoothReceiver.kt`: escucha `BluetoothDevice.ACTION_ACL_CONNECTED` y `ACTION_ACL_DISCONNECTED`, filtra por MAC/nombre y notifica al servicio.
+- `HotspotForegroundService.kt`: mantiene proceso en primer plano con notificación persistente e intenta gestionar hotspot según versión de Android.
+- `AndroidManifest.xml`: permisos, receiver y foreground service.
+
+## Consideraciones Android 11/12/13+
+
+1. **No existe API pública estable para activar/desactivar tethering completo** (compartir datos móviles) para apps de terceros.
+2. `TetheringManager.startTethering(...)` normalmente requiere permisos privilegiados (`TETHER_PRIVILEGED`), reservados para apps de sistema/OEM.
+3. `WRITE_SETTINGS` puede servir en escenarios legacy, pero en Android modernos ya no garantiza el control total del hotspot.
+4. La alternativa soportada por API pública es `WifiManager.startLocalOnlyHotspot()`, que **no comparte internet móvil**.
+5. En práctica, para Android 11+ la estrategia recomendada para apps normales es:
+   - Abrir la pantalla de ajustes de hotspot mediante `Intent` (ej. `Settings.ACTION_WIRELESS_SETTINGS` o pantalla específica del OEM).
+   - Opcionalmente usar automatización por accesibilidad (con consentimiento explícito del usuario), sabiendo que es más frágil por cambios de UI.
+
+## Permisos clave
+
+- `BLUETOOTH_CONNECT` (Android 12+)
+- `ACCESS_FINE_LOCATION` (compatibilidad de metadatos/escaneo BT en versiones previas)
+- `FOREGROUND_SERVICE`
+- `WRITE_SETTINGS` (permiso especial: el usuario debe habilitarlo manualmente en ajustes)
+
+## Nota práctica
+
+Si necesitas una solución robusta sin pelear con restricciones OEM/API, considera herramientas como **MacroDroid** o **Tasker**, que ya cubren parte de estos flujos de automatización con configuraciones del usuario.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.carhotspot">
+
+    <!-- Bluetooth + detección de dispositivos -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
+    <!-- En Android 11 o menor, el escaneo/metadata BT puede requerir ubicación -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
+    <!-- Requerido para mantener servicio activo -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
+    <!-- Permiso especial para modificar ajustes del sistema (debe concederse por pantalla de ajustes) -->
+    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
+
+    <!-- Opcional: rearmar servicio al arrancar -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
+    <application
+        android:allowBackup="true"
+        android:label="Car Hotspot Automation"
+        android:supportsRtl="true">
+
+        <service
+            android:name=".HotspotForegroundService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
+
+        <receiver
+            android:name=".CarBluetoothReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
+                <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED" />
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/carhotspot/CarBluetoothReceiver.kt
+++ b/app/src/main/java/com/example/carhotspot/CarBluetoothReceiver.kt
@@ -1,0 +1,68 @@
+package com.example.carhotspot
+
+import android.bluetooth.BluetoothDevice
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+
+class CarBluetoothReceiver : BroadcastReceiver() {
+
+    companion object {
+        /**
+         * Configuración rápida (hardcode). En producción puedes moverlo a SharedPreferences.
+         */
+        private const val CAR_DEVICE_MAC = "00:11:22:33:44:55"
+        private const val CAR_DEVICE_NAME = "MiCoche_BT"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            Intent.ACTION_BOOT_COMPLETED -> {
+                // Arranca servicio para quedar residente con notificación persistente.
+                context.startForegroundService(
+                    Intent(context, HotspotForegroundService::class.java).apply {
+                        action = HotspotForegroundService.ACTION_START_MONITORING
+                    }
+                )
+            }
+
+            BluetoothDevice.ACTION_ACL_CONNECTED,
+            BluetoothDevice.ACTION_ACL_DISCONNECTED -> {
+                val device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
+                    ?: return
+
+                if (!matchesCar(device)) return
+
+                val serviceAction = if (intent.action == BluetoothDevice.ACTION_ACL_CONNECTED) {
+                    HotspotForegroundService.ACTION_CAR_CONNECTED
+                } else {
+                    HotspotForegroundService.ACTION_CAR_DISCONNECTED
+                }
+
+                context.startForegroundService(
+                    Intent(context, HotspotForegroundService::class.java).apply {
+                        action = serviceAction
+                        putExtra(HotspotForegroundService.EXTRA_DEVICE_NAME, device.name)
+                        putExtra(HotspotForegroundService.EXTRA_DEVICE_MAC, device.address)
+                    }
+                )
+            }
+        }
+    }
+
+    private fun matchesCar(device: BluetoothDevice): Boolean {
+        val macMatches = device.address.equals(CAR_DEVICE_MAC, ignoreCase = true)
+        val nameMatches = device.name?.equals(CAR_DEVICE_NAME, ignoreCase = true) == true
+        return macMatches || nameMatches
+    }
+
+    private fun <T> Intent.getParcelableExtra(key: String, clazz: Class<T>): T? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getParcelableExtra(key, clazz)
+        } else {
+            @Suppress("DEPRECATION")
+            getParcelableExtra(key)
+        }
+    }
+}

--- a/app/src/main/java/com/example/carhotspot/HotspotForegroundService.kt
+++ b/app/src/main/java/com/example/carhotspot/HotspotForegroundService.kt
@@ -1,0 +1,178 @@
+package com.example.carhotspot
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.net.wifi.WifiManager
+import android.os.Build
+import android.os.IBinder
+import android.provider.Settings
+import androidx.core.app.NotificationCompat
+
+class HotspotForegroundService : Service() {
+
+    companion object {
+        const val CHANNEL_ID = "car_hotspot_channel"
+        const val NOTIFICATION_ID = 1001
+
+        const val ACTION_START_MONITORING = "com.example.carhotspot.ACTION_START_MONITORING"
+        const val ACTION_CAR_CONNECTED = "com.example.carhotspot.ACTION_CAR_CONNECTED"
+        const val ACTION_CAR_DISCONNECTED = "com.example.carhotspot.ACTION_CAR_DISCONNECTED"
+
+        const val EXTRA_DEVICE_NAME = "extra_device_name"
+        const val EXTRA_DEVICE_MAC = "extra_device_mac"
+    }
+
+    private var localOnlyReservation: WifiManager.LocalOnlyHotspotReservation? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+        startForeground(NOTIFICATION_ID, buildNotification("Monitoreando Bluetooth del coche"))
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_START_MONITORING -> {
+                updateNotification("Servicio activo y escuchando conexión del coche")
+            }
+
+            ACTION_CAR_CONNECTED -> {
+                val name = intent.getStringExtra(EXTRA_DEVICE_NAME) ?: "Coche"
+                val ok = enableHotspotOrFallback()
+                val message = if (ok) {
+                    "Conectado a $name: intento de hotspot ejecutado"
+                } else {
+                    "Conectado a $name: abre ajustes para activar hotspot manualmente"
+                }
+                updateNotification(message)
+            }
+
+            ACTION_CAR_DISCONNECTED -> {
+                val name = intent.getStringExtra(EXTRA_DEVICE_NAME) ?: "Coche"
+                val ok = disableHotspotOrFallback()
+                val message = if (ok) {
+                    "Desconectado de $name: intento de apagado de hotspot ejecutado"
+                } else {
+                    "Desconectado de $name: abre ajustes para desactivar hotspot manualmente"
+                }
+                updateNotification(message)
+            }
+        }
+
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun enableHotspotOrFallback(): Boolean {
+        // Android 11/12/13+: No hay API pública para Tethering completo para apps normales.
+        // Se usa LocalOnlyHotspot (sin compartir internet móvil) como alternativa técnica.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+            return try {
+                wifiManager.startLocalOnlyHotspot(
+                    object : WifiManager.LocalOnlyHotspotCallback() {
+                        override fun onStarted(reservation: WifiManager.LocalOnlyHotspotReservation) {
+                            localOnlyReservation = reservation
+                        }
+                    },
+                    null
+                )
+                true
+            } catch (_: Exception) {
+                openTetherSettings()
+                false
+            }
+        }
+
+        // APIs antiguas (pre-O): posible por reflexión + WRITE_SETTINGS.
+        return setLegacyWifiApEnabled(true)
+    }
+
+    private fun disableHotspotOrFallback(): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // Cierra la sesión LocalOnlyHotspot si se abrió.
+            localOnlyReservation?.close()
+            localOnlyReservation = null
+
+            // Intento no privilegiado en APIs modernas: abrir ajustes de hotspot.
+            openTetherSettings()
+            return false
+        }
+
+        return setLegacyWifiApEnabled(false)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun setLegacyWifiApEnabled(enabled: Boolean): Boolean {
+        if (!Settings.System.canWrite(this)) {
+            openWriteSettingsScreen()
+            return false
+        }
+
+        return try {
+            val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+            val method = wifiManager.javaClass.getMethod("setWifiApEnabled", android.net.wifi.WifiConfiguration::class.java, Boolean::class.javaPrimitiveType)
+            method.invoke(wifiManager, null, enabled)
+            true
+        } catch (_: Exception) {
+            openTetherSettings()
+            false
+        }
+    }
+
+    private fun openWriteSettingsScreen() {
+        val intent = Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS).apply {
+            data = android.net.Uri.parse("package:$packageName")
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        startActivity(intent)
+    }
+
+    private fun openTetherSettings() {
+        val intent = Intent().apply {
+            action = Settings.ACTION_WIRELESS_SETTINGS
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        startActivity(intent)
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Car Hotspot Service",
+                NotificationManager.IMPORTANCE_LOW
+            )
+            val manager = getSystemService(NotificationManager::class.java)
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    private fun buildNotification(contentText: String): Notification {
+        val openSettingsIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(Settings.ACTION_WIRELESS_SETTINGS),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setContentTitle("Car Hotspot Automation")
+            .setContentText(contentText)
+            .setContentIntent(openSettingsIntent)
+            .setOngoing(true)
+            .build()
+    }
+
+    private fun updateNotification(text: String) {
+        val notificationManager = getSystemService(NotificationManager::class.java)
+        notificationManager.notify(NOTIFICATION_ID, buildNotification(text))
+    }
+}


### PR DESCRIPTION
### Motivation
- Automatizar el encendido/apagado del Punto de Acceso (Hotspot) cuando se conecta/desconecta el Bluetooth del coche y evitar activaciones por otros dispositivos.
- Soportar persistencia del proceso mediante un `Foreground Service` para evitar que el sistema mate la aplicación en segundo plano.
- Manejar las restricciones modernas de Android sobre control de tethering (API restringidas, `WRITE_SETTINGS`, alternativas como `LocalOnlyHotspot` o abrir ajustes).

### Description
- Añadido `CarBluetoothReceiver.kt` que escucha `BluetoothDevice.ACTION_ACL_CONNECTED` y `ACTION_ACL_DISCONNECTED`, filtra por MAC o nombre del coche (hardcodeado) y envía acciones al servicio foreground; también arranca el servicio en `BOOT_COMPLETED`.
- Añadido `HotspotForegroundService.kt` que mantiene notificación persistente (`startForeground`) y gestiona los eventos de conexión/desconexión intentando activar `startLocalOnlyHotspot()` en APIs modernas, con fallback a abrir pantalla de ajustes (`Settings.ACTION_WIRELESS_SETTINGS`) y ruta legacy por reflexión a `setWifiApEnabled` protegida por `WRITE_SETTINGS`.
- Añadido `AndroidManifest.xml` con permisos clave (`BLUETOOTH_CONNECT`, `ACCESS_FINE_LOCATION`, `FOREGROUND_SERVICE`, `WRITE_SETTINGS`, `RECEIVE_BOOT_COMPLETED`) y declaración del `BroadcastReceiver` y del `Service` con `foregroundServiceType="connectedDevice"`.
- Documentación en `README.md` que explica las limitaciones en Android 11/12/13+, las alternativas prácticas (abrir ajustes, accesibilidad, o usar MacroDroid/Tasker) y los permisos especiales necesarios.

### Testing
- Ejecutado `git diff --check` para verificar problemas de formato y no reportó errores (exitoso).
- Comprobado estado con `git status --short` para confirmar los archivos añadidos (exitoso).
- Los ficheros se añadieron y se guardó un commit que contiene `AndroidManifest.xml`, `CarBluetoothReceiver.kt`, `HotspotForegroundService.kt` y la actualización de `README.md` (commit realizado correctamente).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a602afb9b4832dbe075a772584d882)